### PR TITLE
Refactor Vercel setup to use serverless functions and updates SSR.

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,9 @@
+// This file serves as the entry point for Vercel's serverless function
+// It imports the Angular SSR server and handles requests
+
+// Import required modules
+const path = require('path');
+
+const serverDistPath = path.join(process.cwd(), 'dist/angular-ssr-vercel/server/server.mjs');
+
+export default import(serverDistPath).then(module => module.app);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "serve:ssr:angular-ssr-vercel": "node dist/angular-ssr-vercel/server/server.mjs"
+    "serve:ssr:angular-ssr-vercel": "node dist/angular-ssr-vercel/server/server.mjs",
+    "vercel-build": "ng build"
   },
   "private": true,
   "dependencies": {

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -3,6 +3,6 @@ import { RenderMode, ServerRoute } from '@angular/ssr';
 export const serverRoutes: ServerRoute[] = [
   {
     path: '**',
-    renderMode: RenderMode.Prerender
+    renderMode: RenderMode.Server
   }
 ];

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 const serverDistFolder = dirname(fileURLToPath(import.meta.url));
 const browserDistFolder = resolve(serverDistFolder, '../browser');
 
-const app = express();
+export const app = express();
 const angularApp = new AngularNodeAppEngine();
 
 /**

--- a/vercel.json
+++ b/vercel.json
@@ -1,17 +1,16 @@
 {
   "version": 2,
-  "builds": [
+  "public": true,
+  "name": "angular-ssr-vercel",
+  "rewrites": [
     {
-      "src": "dist/angular-ssr-vercel/server/server.mjs",
-      "use": "@vercel/node"
+      "source": "/(.*)",
+      "destination": "/api"
     }
   ],
-  "routes": [
-    {
-      "src": "/(.*)",
-      "dest": "dist/angular-ssr-vercel/server/server.mjs"
+  "functions": {
+    "api/index.js": {
+      "includeFiles": "dist/angular-ssr-vercel/**"
     }
-  ],
-  "buildCommand": "npm run build",
-  "outputDirectory": "dist/angular-ssr-vercel/browser"
+  }
 }


### PR DESCRIPTION
Replaces the build and routing configuration in `vercel.json` to support Vercel's serverless function deployment model. Updates server-side rendering (SSR) logic by exporting the Express app and changing default render mode to `RenderMode.Server`. Adds a new serverless entry point file under `api/index.js` and adjusts build scripts for compatibility.